### PR TITLE
Moving SqlCeConnectionExtensions to Internal

### DIFF
--- a/src/Design35/EntityFramework.SqlServerCompact35.Design.csproj
+++ b/src/Design35/EntityFramework.SqlServerCompact35.Design.csproj
@@ -80,7 +80,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>

--- a/src/Design40/EntityFramework.SqlServerCompact40.Design.csproj
+++ b/src/Design40/EntityFramework.SqlServerCompact40.Design.csproj
@@ -83,7 +83,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>

--- a/src/Provider35/EntityFramework.SqlServerCompact35.csproj
+++ b/src/Provider35/EntityFramework.SqlServerCompact35.csproj
@@ -76,7 +76,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
@@ -107,9 +106,6 @@
     </Compile>
     <Compile Include="..\Provider40\Extensions\Logging\NullLogger.cs">
       <Link>Extensions\Logging\NullLogger.cs</Link>
-    </Compile>
-    <Compile Include="..\Provider40\Extensions\SqlCeConnectionExtensions.cs">
-      <Link>Extensions\SqlCeConnectionExtensions.cs</Link>
     </Compile>
     <Compile Include="..\Provider40\Extensions\SqlCeDbContextExtensions.cs">
       <Link>Extensions\SqlCeDbContextExtensions.cs</Link>
@@ -236,6 +232,9 @@
     </Compile>
     <Compile Include="..\Provider40\Storage\Internal\ISqlCeDatabaseConnection.cs">
       <Link>Storage\Internal\ISqlCeDatabaseConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\Provider40\Storage\Internal\SqlCeConnectionExtensions.cs">
+      <Link>Storage\Internal\SqlCeConnectionExtensions.cs</Link>
     </Compile>
     <Compile Include="..\Provider40\Storage\Internal\SqlCeDatabaseConnection.cs">
       <Link>Storage\Internal\SqlCeDatabaseConnection.cs</Link>

--- a/src/Provider40/EntityFramework.SqlServerCompact40.csproj
+++ b/src/Provider40/EntityFramework.SqlServerCompact40.csproj
@@ -76,7 +76,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
@@ -103,7 +102,7 @@
     <Compile Include="Extensions\Logging\DbConsoleLogger.cs" />
     <Compile Include="Extensions\Logging\DbLoggerProvider.cs" />
     <Compile Include="Extensions\Logging\NullLogger.cs" />
-    <Compile Include="Extensions\SqlCeConnectionExtensions.cs" />
+    <Compile Include="Storage\Internal\SqlCeConnectionExtensions.cs" />
     <Compile Include="Extensions\SqlCeDbContextExtensions.cs" />
     <Compile Include="Extensions\SqlCeEntityTypeBuilderExtensions.cs" />
     <Compile Include="Extensions\SqlCeIndexBuilderExtensions.cs" />

--- a/src/Provider40/Extensions/SqlCeDbContextExtensions.cs
+++ b/src/Provider40/Extensions/SqlCeDbContextExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Extensions.Logging;
@@ -10,6 +9,10 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlCeDbContextExtensions
     {
+        /// <summary>
+        ///     Configures the context to log all SQL statements to the Console
+        /// </summary>
+        /// <param name="context"> The context. </param>
         public static void LogToConsole([NotNull] this DbContext context)
         {
             Check.NotNull(context, nameof(context));

--- a/src/Provider40/Extensions/SqlCeDbContextOptionsExtensions.cs
+++ b/src/Provider40/Extensions/SqlCeDbContextOptionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data.Common;
+using System.Data.SqlServerCe;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
@@ -10,35 +11,72 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlCeDbContextOptionsExtensions
     {
-        public static SqlCeDbContextOptionsBuilder UseSqlCe([NotNull] this DbContextOptionsBuilder options, [NotNull] string connectionString)
+#if SQLCE35
+#else
+        /// <summary>
+        ///     Configures the context to connect to a Microsoft SQL Server Compact database.
+        /// </summary>
+        /// <param name="optionsBuilder"> The options for the context. </param>
+        /// <param name="connectionStringBuilder"> The connection string builder for the database to connect to. </param>
+        /// <returns> An options builder to allow additional SQL Server Compact specific configuration. </returns>
+        public static SqlCeDbContextOptionsBuilder UseSqlCe([NotNull] this DbContextOptionsBuilder optionsBuilder, [NotNull] SqlCeConnectionStringBuilder connectionStringBuilder)
         {
-            Check.NotNull(options, nameof(options));
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+            Check.NotNull(connectionStringBuilder, nameof(connectionStringBuilder));
+
+            var extension = GetOrCreateExtension(optionsBuilder);
+            extension.ConnectionString = connectionStringBuilder.ConnectionString;
+            extension.MaxBatchSize = 1;
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            return new SqlCeDbContextOptionsBuilder(optionsBuilder);
+        }
+#endif
+        /// <summary>
+        ///     Configures the context to connect to a Microsoft SQL Server Compact database.
+        /// </summary>
+        /// <param name="optionsBuilder"> The options for the context. </param>
+        /// <param name="connectionString"> The connection string for the database to connect to. </param>
+        /// <returns> An options builder to allow additional SQL Server Compact specific configuration. </returns>
+        public static SqlCeDbContextOptionsBuilder UseSqlCe([NotNull] this DbContextOptionsBuilder optionsBuilder, [NotNull] string connectionString)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
             Check.NotEmpty(connectionString, nameof(connectionString));
 
-            var extension = GetOrCreateExtension(options);
+            var extension = GetOrCreateExtension(optionsBuilder);
             extension.ConnectionString = connectionString;
             extension.MaxBatchSize = 1;
-            ((IDbContextOptionsBuilderInfrastructure)options).AddOrUpdateExtension(extension);
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
-            return new SqlCeDbContextOptionsBuilder(options);
+            return new SqlCeDbContextOptionsBuilder(optionsBuilder);
         }
- 
-        public static SqlCeDbContextOptionsBuilder UseSqlCe([NotNull] this DbContextOptionsBuilder options, [NotNull] DbConnection connection)
+
+        /// <summary>
+        ///     Configures the context to connect to a Microsoft SQL Server Compact database.
+        /// </summary>
+        /// <param name="optionsBuilder"> The options for the context. </param>
+        /// <param name="connection">
+        ///     An existing <see cref="DbConnection" /> to be used to connect to the database. If the connection is
+        ///     in the open state then EF will not open or close the connection. If the connection is in the closed
+        ///     state then EF will open and close the connection as needed.
+        /// </param>
+        /// <returns> An options builder to allow additional SQL Server Compact specific configuration. </returns> 
+        public static SqlCeDbContextOptionsBuilder UseSqlCe([NotNull] this DbContextOptionsBuilder optionsBuilder, [NotNull] DbConnection connection)
         {
-            Check.NotNull(options, nameof(options));
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
             Check.NotNull(connection, nameof(connection));
 
-            var extension = GetOrCreateExtension(options);
+            var extension = GetOrCreateExtension(optionsBuilder);
             extension.Connection = connection;
             extension.MaxBatchSize = 1;
-            ((IDbContextOptionsBuilderInfrastructure)options).AddOrUpdateExtension(extension);
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
-            return new SqlCeDbContextOptionsBuilder(options);
+            return new SqlCeDbContextOptionsBuilder(optionsBuilder);
         }
 
-        private static SqlCeOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder options)
+        private static SqlCeOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder optionsBuilder)
         {
-            var existingExtension = options.Options.FindExtension<SqlCeOptionsExtension>();
+            var existingExtension = optionsBuilder.Options.FindExtension<SqlCeOptionsExtension>();
 
             return existingExtension != null
                 ? new SqlCeOptionsExtension(existingExtension)

--- a/src/Provider40/Extensions/SqlCeEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/Provider40/Extensions/SqlCeEntityFrameworkServicesBuilderExtensions.cs
@@ -21,11 +21,40 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class SqlCeEntityFrameworkServicesBuilderExtensions
     {
-        public static EntityFrameworkServicesBuilder AddSqlCe([NotNull] this EntityFrameworkServicesBuilder services)
+        /// <summary>
+        ///     <para>
+        ///         Adds the services required by the Microsoft SQL Server Compact database provider for Entity Framework
+        ///         to an <see cref="IServiceCollection" />. You use this method when using dependency injection
+        ///         in your application, such as with ASP.NET. For more information on setting up dependency
+        ///         injection, see http://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        ///     <para>
+        ///         You only need to use this functionality when you want Entity Framework to resolve the services it uses
+        ///         from an external <see cref="IServiceCollection" />. If you are not using an external
+        ///         <see cref="IServiceCollection" /> Entity Framework will take care of creating the services it requires.
+        ///     </para>
+        /// </summary>
+        /// <example>
+        ///     <code>
+        ///         public void ConfigureServices(IServiceCollection services) 
+        ///         {
+        ///             var connectionString = "connection string to database";
+        /// 
+        ///             services.AddEntityFramework() 
+        ///                 .AddSqlCe()
+        ///                 .AddDbContext&lt;MyContext&gt;(options => options.UseSqlCe(connectionString)); 
+        ///         }
+        ///     </code>
+        /// </example>
+        /// <param name="builder"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <returns>
+        ///     A builder that allows further Entity Framework specific setup of the <see cref="IServiceCollection" />.
+        /// </returns>
+        public static EntityFrameworkServicesBuilder AddSqlCe([NotNull] this EntityFrameworkServicesBuilder builder)
         {
-            Check.NotNull(services, nameof(services));
+            Check.NotNull(builder, nameof(builder));
 
-            var service = services.AddRelational().GetInfrastructure();
+            var service = builder.AddRelational().GetInfrastructure();
 
             service.TryAddEnumerable(ServiceDescriptor
                 .Singleton<IDatabaseProvider, DatabaseProvider<SqlCeDatabaseProviderServices, SqlCeOptionsExtension>>());
@@ -48,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddQuery()
                 );
 
-            return services;
+            return builder;
         }
 
         private static IServiceCollection AddQuery(this IServiceCollection serviceCollection)

--- a/src/Provider40/Extensions/SqlCeEntityTypeBuilderExtensions.cs
+++ b/src/Provider40/Extensions/SqlCeEntityTypeBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlCeEntityTypeBuilderExtensions
     {
-        public static EntityTypeBuilder ToSqlCeTable([NotNull] this EntityTypeBuilder builder, [CanBeNull] string name)
+        public static EntityTypeBuilder ForSqlCeToTable([NotNull] this EntityTypeBuilder builder, [CanBeNull] string name)
         {
             Check.NotNull(builder, nameof(builder));
             Check.NullButNotEmpty(name, nameof(name));
@@ -18,10 +18,10 @@ namespace Microsoft.Data.Entity
             return builder;
         }
 
-        public static EntityTypeBuilder<TEntity> ToSqlCeTable<TEntity>(
+        public static EntityTypeBuilder<TEntity> ForSqlCeToTable<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> builder,
             [CanBeNull] string name)
             where TEntity : class
-            => (EntityTypeBuilder<TEntity>)((EntityTypeBuilder)builder).ToSqlCeTable(name);
+            => (EntityTypeBuilder<TEntity>)((EntityTypeBuilder)builder).ForSqlCeToTable(name);
     }
 }

--- a/src/Provider40/Extensions/SqlCeIndexBuilderExtensions.cs
+++ b/src/Provider40/Extensions/SqlCeIndexBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlCeIndexBuilderExtensions
     {
-        public static IndexBuilder SqlCeIndexName([NotNull] this IndexBuilder builder, [CanBeNull] string name)
+        public static IndexBuilder ForSqlCeHasName([NotNull] this IndexBuilder builder, [CanBeNull] string name)
         {
             Check.NotNull(builder, nameof(builder));
             Check.NullButNotEmpty(name, nameof(name));

--- a/src/Provider40/Extensions/SqlCeKeyBuilderExtensions.cs
+++ b/src/Provider40/Extensions/SqlCeKeyBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlCeKeyBuilderExtensions
     {
-        public static KeyBuilder SqlCeKeyName([NotNull] this KeyBuilder builder, [CanBeNull] string name)
+        public static KeyBuilder ForSqlCeHasName([NotNull] this KeyBuilder builder, [CanBeNull] string name)
         {
             Check.NotNull(builder, nameof(builder));
             Check.NullButNotEmpty(name, nameof(name));

--- a/src/Provider40/Extensions/SqlCePropertyBuilderExtensions.cs
+++ b/src/Provider40/Extensions/SqlCePropertyBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlCePropertyBuilderExtensions
     {
-        public static PropertyBuilder HasSqlCeColumnName([NotNull] this PropertyBuilder builder, [CanBeNull] string name)
+        public static PropertyBuilder ForSqlCeHasColumnName([NotNull] this PropertyBuilder builder, [CanBeNull] string name)
         {
             Check.NotNull(builder, nameof(builder));
             Check.NullButNotEmpty(name, nameof(name));
@@ -18,11 +18,11 @@ namespace Microsoft.Data.Entity
             return builder;
         }
 
-        public static PropertyBuilder<TEntity> HasSqlCeColumnName<TEntity>(
+        public static PropertyBuilder<TEntity> ForSqlCeHasColumnName<TEntity>(
             [NotNull] this PropertyBuilder<TEntity> builder,
             [CanBeNull] string name)
             where TEntity : class
-            => (PropertyBuilder<TEntity>)((PropertyBuilder)builder).HasSqlCeColumnName(name);
+            => (PropertyBuilder<TEntity>)((PropertyBuilder)builder).ForSqlCeHasColumnName(name);
 
         public static PropertyBuilder HasSqlCeColumnType([NotNull] this PropertyBuilder builder, [CanBeNull] string type)
         {
@@ -34,13 +34,13 @@ namespace Microsoft.Data.Entity
             return builder;
         }
 
-        public static PropertyBuilder<TEntity> HasSqlCeColumnType<TEntity>(
+        public static PropertyBuilder<TEntity> ForSqlCeHasColumnType<TEntity>(
             [NotNull] this PropertyBuilder<TEntity> builder,
             [CanBeNull] string type)
             where TEntity : class
             => (PropertyBuilder<TEntity>)((PropertyBuilder)builder).HasSqlCeColumnType(type);
 
-        public static PropertyBuilder HasSqlCeDefaultValueSql(
+        public static PropertyBuilder ForSqlCeHasDefaultValueSql(
             [NotNull] this PropertyBuilder builder,
             [CanBeNull] string sql)
         {
@@ -53,10 +53,10 @@ namespace Microsoft.Data.Entity
             return builder;
         }
 
-        public static PropertyBuilder<TEntity> HasSqlCeDefaultValueSql<TEntity>(
+        public static PropertyBuilder<TEntity> ForSqlCeHasDefaultValueSql<TEntity>(
             [NotNull] this PropertyBuilder<TEntity> builder,
             [CanBeNull] string sql)
             where TEntity : class
-            => (PropertyBuilder<TEntity>)((PropertyBuilder)builder).HasSqlCeDefaultValueSql(sql);
+            => (PropertyBuilder<TEntity>)((PropertyBuilder)builder).ForSqlCeHasDefaultValueSql(sql);
     }
 }

--- a/src/Provider40/Extensions/SqlCeReferenceCollectionBuilderExtensions.cs
+++ b/src/Provider40/Extensions/SqlCeReferenceCollectionBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlCeReferenceCollectionBuilderExtensions
     {
-        public static ReferenceCollectionBuilder SqlCeConstraintName(
+        public static ReferenceCollectionBuilder ForSqlCeHasConstraintName(
             [NotNull] this ReferenceCollectionBuilder builder,
             [CanBeNull] string name)
         {
@@ -20,11 +20,11 @@ namespace Microsoft.Data.Entity
             return builder;
         }
 
-        public static ReferenceCollectionBuilder<TEntity, TReferencedEntity> SqlCeConstraintName<TEntity, TReferencedEntity>(
+        public static ReferenceCollectionBuilder<TEntity, TReferencedEntity> ForSqlCeHasConstraintName<TEntity, TReferencedEntity>(
             [NotNull] this ReferenceCollectionBuilder<TEntity, TReferencedEntity> builder,
             [CanBeNull] string name)
             where TEntity : class
             where TReferencedEntity : class
-            => (ReferenceCollectionBuilder<TEntity, TReferencedEntity>)((ReferenceCollectionBuilder)builder).SqlCeConstraintName(name);
+            => (ReferenceCollectionBuilder<TEntity, TReferencedEntity>)((ReferenceCollectionBuilder)builder).ForSqlCeHasConstraintName(name);
     }
 }

--- a/src/Provider40/Extensions/SqlCeReferenceReferenceBuilderExtensions.cs
+++ b/src/Provider40/Extensions/SqlCeReferenceReferenceBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlCeReferenceReferenceBuilderExtensions
     {
-        public static ReferenceReferenceBuilder SqlCeConstraintName(
+        public static ReferenceReferenceBuilder ForSqlCeHasConstraintName(
             [NotNull] this ReferenceReferenceBuilder builder,
             [CanBeNull] string name)
         {
@@ -20,11 +20,11 @@ namespace Microsoft.Data.Entity
             return builder;
         }
 
-        public static ReferenceReferenceBuilder<TEntity, TReferencedEntity> SqlCeConstraintName<TEntity, TReferencedEntity>(
+        public static ReferenceReferenceBuilder<TEntity, TReferencedEntity> ForSqlCeHasConstraintName<TEntity, TReferencedEntity>(
             [NotNull] this ReferenceReferenceBuilder<TEntity, TReferencedEntity> builder,
             [CanBeNull] string name)
             where TEntity : class
             where TReferencedEntity : class
-            => (ReferenceReferenceBuilder<TEntity, TReferencedEntity>)((ReferenceReferenceBuilder)builder).SqlCeConstraintName(name);
+            => (ReferenceReferenceBuilder<TEntity, TReferencedEntity>)((ReferenceReferenceBuilder)builder).ForSqlCeHasConstraintName(name);
     }
 }

--- a/src/Provider40/Storage/Internal/SqlCeConnectionExtensions.cs
+++ b/src/Provider40/Storage/Internal/SqlCeConnectionExtensions.cs
@@ -3,9 +3,7 @@ using System.IO;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
-// ReSharper disable once CheckNamespace
-
-namespace Microsoft.Data.Entity
+namespace Microsoft.Data.Entity.Storage.Internal
 {
     public static class SqlCeConnectionExtensions
     {

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/BasicEndToEndScenarioForIdentity.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/BasicEndToEndScenarioForIdentity.cs
@@ -26,7 +26,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public class BloggingContext : DbContext
         {
             public DbSet<Blog> Blogs { get; set; }
-
+#if SQLCE35
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseSqlCe(@"Data Source=BloggingIdentity.sdf");
+            }
+#else
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
                 optionsBuilder.UseSqlCe(
@@ -36,6 +41,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     }
                     .ConnectionString);
             }
+#endif
         }
 
         public class Blog

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/BasicEndToEndScenarioForIdentity.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/BasicEndToEndScenarioForIdentity.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Data.SqlServerCe;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
@@ -28,7 +29,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseSqlCe(@"Data Source=BloggingIdentity.sdf");
+                optionsBuilder.UseSqlCe(
+                    new SqlCeConnectionStringBuilder
+                    {
+                        DataSource = "BloggingIdentity.sdf"
+                    }
+                    .ConnectionString);
             }
         }
 

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/EntityFramework.SqlServerCompact.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/EntityFramework.SqlServerCompact.FunctionalTests.csproj
@@ -94,7 +94,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>

--- a/test/EntityFramework.SqlServerCompact.FunctionalTests/SqlCeTestStore.cs
+++ b/test/EntityFramework.SqlServerCompact.FunctionalTests/SqlCeTestStore.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Storage.Internal;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {

--- a/test/EntityFramework.SqlServerCompact.Tests/EntityFramework.SqlServerCompact.Tests.csproj
+++ b/test/EntityFramework.SqlServerCompact.Tests/EntityFramework.SqlServerCompact.Tests.csproj
@@ -98,7 +98,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>

--- a/test/EntityFramework.SqlServerCompact.Tests/Extensions/Metadata/Builders/SqlCeBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServerCompact.Tests/Extensions/Metadata/Builders/SqlCeBuilderExtensionsTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
             var property = modelBuilder
                 .Entity<Customer>()
                 .Property(e => e.Name)
-                .HasSqlCeColumnName("MyNameIs")
+                .ForSqlCeHasColumnName("MyNameIs")
                 .Metadata;
 
             Assert.Equal("MyNameIs", property.SqlCe().ColumnName);
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
             var property = modelBuilder
                 .Entity<Customer>()
                 .Property<string>("Name")
-                .HasSqlCeColumnName("MyNameIs")
+                .ForSqlCeHasColumnName("MyNameIs")
                 .Metadata;
 
             Assert.Equal("MyNameIs", property.SqlCe().ColumnName);
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
             var property = modelBuilder
                 .Entity<Customer>()
                 .Property(e => e.Name)
-                .HasSqlCeColumnType("nvarchar(DA)")
+                .ForSqlCeHasColumnType("nvarchar(DA)")
                 .Metadata;
 
             Assert.Equal("nvarchar(DA)", property.SqlCe().ColumnType);
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
             var property = modelBuilder
                 .Entity<Customer>()
                 .Property<string>("Name")
-                .HasSqlCeColumnType("nvarchar(DA)")
+                .ForSqlCeHasColumnType("nvarchar(DA)")
                 .Metadata;
 
             Assert.Equal("nvarchar(DA)", property.SqlCe().ColumnType);
@@ -70,7 +70,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
             var property = modelBuilder
                 .Entity<Customer>()
                 .Property(e => e.Name)
-                .HasSqlCeDefaultValueSql("VanillaCoke")
+                .ForSqlCeHasDefaultValueSql("VanillaCoke")
                 .Metadata;
 
             Assert.Equal("VanillaCoke", property.SqlCe().GeneratedValueSql);
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
             var property = modelBuilder
                 .Entity<Customer>()
                 .Property<string>("Name")
-                .HasSqlCeDefaultValueSql("VanillaCoke")
+                .ForSqlCeHasDefaultValueSql("VanillaCoke")
                 .Metadata;
 
             Assert.Equal("VanillaCoke", property.SqlCe().GeneratedValueSql);
@@ -98,7 +98,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
             var key = modelBuilder
                 .Entity<Customer>()
                 .HasKey(e => e.Id)
-                .SqlCeKeyName("LemonSupreme")
+                .ForSqlCeHasName("LemonSupreme")
                 .Metadata;
 
             Assert.Equal("LemonSupreme", key.SqlCe().Name);
@@ -111,7 +111,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
 
             var foreignKey = modelBuilder
                 .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
-                .SqlCeConstraintName("ChocolateLimes")
+                .ForSqlCeHasConstraintName("ChocolateLimes")
                 .Metadata;
 
             Assert.Equal("ChocolateLimes", foreignKey.SqlCe().Name);
@@ -124,7 +124,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
 
             var foreignKey = modelBuilder
                 .Entity<Customer>().HasMany(typeof(Order)).WithOne()
-                .SqlCeConstraintName("ChocolateLimes")
+                .ForSqlCeHasConstraintName("ChocolateLimes")
                 .Metadata;
 
             Assert.Equal("ChocolateLimes", foreignKey.SqlCe().Name);
@@ -137,7 +137,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
 
             var foreignKey = modelBuilder
                 .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
-                .SqlCeConstraintName("ChocolateLimes")
+                .ForSqlCeHasConstraintName("ChocolateLimes")
                 .Metadata;
 
             Assert.Equal("ChocolateLimes", foreignKey.SqlCe().Name);
@@ -150,7 +150,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
 
             var foreignKey = modelBuilder
                 .Entity<Order>().HasMany(typeof(Customer)).WithOne()
-                .SqlCeConstraintName("ChocolateLimes")
+                .ForSqlCeHasConstraintName("ChocolateLimes")
                 .Metadata;
 
             Assert.Equal("ChocolateLimes", foreignKey.SqlCe().Name);
@@ -163,7 +163,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
 
             var foreignKey = modelBuilder
                 .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
-                .SqlCeConstraintName("ChocolateLimes")
+                .ForSqlCeHasConstraintName("ChocolateLimes")
                 .Metadata;
 
             Assert.Equal("ChocolateLimes", foreignKey.SqlCe().Name);
@@ -176,7 +176,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
 
             var foreignKey = modelBuilder
                 .Entity<Order>().HasMany(typeof(OrderDetails)).WithOne()
-                .SqlCeConstraintName("ChocolateLimes")
+                .ForSqlCeHasConstraintName("ChocolateLimes")
                 .Metadata;
 
             Assert.Equal("ChocolateLimes", foreignKey.SqlCe().Name);
@@ -190,7 +190,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
             var index = modelBuilder
                 .Entity<Customer>()
                 .HasIndex(e => e.Id)
-                .SqlCeIndexName("Dexter")
+                .ForSqlCeHasName("Dexter")
                 .Metadata;
 
             Assert.Equal("Dexter", index.SqlCe().Name);
@@ -203,7 +203,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
 
             var entityType = modelBuilder
                 .Entity<Customer>()
-                .ToSqlCeTable("Custardizer")
+                .ForSqlCeToTable("Custardizer")
                 .Metadata;
 
             Assert.Equal("Custardizer", entityType.SqlCe().TableName);
@@ -216,7 +216,7 @@ namespace Microsoft.Data.Entity.Tests.Extensions.Metadata.Builders
 
             var entityType = modelBuilder
                 .Entity("Customer")
-                .ToSqlCeTable("Custardizer")
+                .ForSqlCeToTable("Custardizer")
                 .Metadata;
 
             Assert.Equal("Custardizer", entityType.SqlCe().TableName);

--- a/test/EntityFramework.SqlServerCompact35.FunctionalTests/EntityFramework.SqlServerCompact35.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServerCompact35.FunctionalTests/EntityFramework.SqlServerCompact35.FunctionalTests.csproj
@@ -94,7 +94,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>

--- a/test/EntityFramework.SqlServerCompact40.Design.FunctionalTest/EntityFramework.SqlServerCompact40.Design.FunctionalTest.csproj
+++ b/test/EntityFramework.SqlServerCompact40.Design.FunctionalTest/EntityFramework.SqlServerCompact40.Design.FunctionalTest.csproj
@@ -229,7 +229,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>

--- a/test/EntityFramework.SqlServerCompact40.Design.FunctionalTest/EntityFramework.SqlServerCompact40.Design.FunctionalTest.csproj
+++ b/test/EntityFramework.SqlServerCompact40.Design.FunctionalTest/EntityFramework.SqlServerCompact40.Design.FunctionalTest.csproj
@@ -280,10 +280,6 @@
       <Name>EntityFramework.SqlServerCompact.FunctionalTests</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
   </Target>

--- a/test/EntityFramework.SqlServerCompact40.Design.FunctionalTest/ReverseEngineering/SqlCeE2ETests.cs
+++ b/test/EntityFramework.SqlServerCompact40.Design.FunctionalTest/ReverseEngineering/SqlCeE2ETests.cs
@@ -72,6 +72,9 @@ namespace EntityFramework.SqlServerCompact40.Design.FunctionalTest.ReverseEngine
                         MetadataReference.CreateFromFile(
                             Assembly.Load(new AssemblyName(
                                 "System.ComponentModel.DataAnnotations, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")).Location),
+                        MetadataReference.CreateFromFile(
+                            Assembly.Load(new AssemblyName(
+                                "System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91")).Location),
 #endif
                     }
         };


### PR DESCRIPTION
Adding XML comment to LogToConsole
Adding XML comments to UseSqlCe, AddSqlCe
Rename other SqlCE extension to match current naming scheme
Added possibility to use SqlCeConnectionStringBuilder
   for UseSqlCE with SQLCE 4.0
Remove references to System.Collections.Concurrent