### PR TITLE
Fixed the InterpretExistsResult condition

### DIFF
--- a/src/Provider40/Migrations/Internal/SqlCeHistoryRepository.cs
+++ b/src/Provider40/Migrations/Internal/SqlCeHistoryRepository.cs
@@ -24,7 +24,7 @@ namespace EFCore.SqlCe.Migrations.Internal
             }
         }
 
-        protected override bool InterpretExistsResult(object value) => value != DBNull.Value;
+        protected override bool InterpretExistsResult(object value) => Convert.ToInt64(value) != 0;
 
         public override string GetCreateIfNotExistsScript() => GetCreateScript();
 


### PR DESCRIPTION
The value is never going to be `NULL`, it's either `0` or (hopefully :)) `1`.